### PR TITLE
Fix invaders to work with new definition of Prelude.Nat.-

### DIFF
--- a/Invaders/Starfield.idr
+++ b/Invaders/Starfield.idr
@@ -16,10 +16,10 @@ StarEff t = { [Starfield ::: STATE (List (Int, Int)), RND] } Eff t
 
 initStarfield : List (Int, Int) -> Nat -> StarEff ()
 initStarfield acc Z = Starfield :- put acc
-initStarfield acc n 
+initStarfield acc (S n)
     = do x <- rndInt 0 639
          y <- rndInt 0 479
-         initStarfield ((x, y) :: acc) (n - 1)
+         initStarfield ((x, y) :: acc) n
 
 updateStarfield : StarEff ()
 updateStarfield = do xs <- Starfield :- get


### PR DESCRIPTION
Namely by eliminating the usage of - (pattern matching on `S n` instead).

Currently it errors with:

```
When checking argument smaller to function Prelude.Nat.-:
        Can't solve goal 
                LTE 1 n
```
